### PR TITLE
修复Felica读写以及CMD_SEND_HEX_DATA的回复

### DIFF
--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -7,7 +7,7 @@
 #elif defined(ESP8266)
 #pragma message "当前的开发板是 ESP8266"
 #define SerialDevice Serial
-#define PN532_SPI_SS D4
+//#define PN532_SPI_SS D4
 #define LED_PIN D5
 
 #elif defined(ESP32)
@@ -196,7 +196,7 @@ typedef union {
           struct {
             uint8_t RW_status[2];
             uint8_t numBlock;
-            uint8_t blockData[1][1][16];
+            uint8_t blockData[4][16];
           };
           uint8_t felica_payload[1];
         };
@@ -385,13 +385,12 @@ void nfc_felica_through() {
       break;
     case FelicaReadWithoutEncryptData:
       {
-        uint16_t serviceCodeList[1] = { (uint16_t)(req.serviceCodeList[1] << 8 | req.serviceCodeList[0]) };
+        uint16_t serviceCodeList = req.serviceCodeList[1] << 8 | req.serviceCodeList[0];
+        uint16_t blockList[4];
         for (uint8_t i = 0; i < req.numBlock; i++) {
-          uint16_t blockList[1] = { (uint16_t)(req.blockList[i][0] << 8 | req.blockList[i][1]) };
-          if (nfc.felica_ReadWithoutEncryption(1, serviceCodeList, 1, blockList, res.blockData[i]) != 1) {
-            memset(res.blockData[i], 0, 16);  // dummy data
-          }
+          blockList[i] = (uint16_t)(req.blockList[i][0] << 8 | req.blockList[i][1]);
         }
+        nfc.felica_ReadWithoutEncryption(1, &serviceCodeList, req.numBlock, blockList, res.blockData);
         res.RW_status[0] = 0;
         res.RW_status[1] = 0;
         res.numBlock = req.numBlock;
@@ -400,7 +399,10 @@ void nfc_felica_through() {
       break;
     case FelicaWriteWithoutEncryptData:
       {
-        res_init(0x0C);  // WriteWithoutEncryption,ignore
+        uint16_t serviceCodeList = req.serviceCodeList[1] << 8 | req.serviceCodeList[0];
+        uint16_t blockList = (uint16_t)(req.blockList_write[0][0] << 8 | req.blockList_write[0][1]);
+        nfc.felica_WriteWithoutEncryption(1, &serviceCodeList, 1, &blockList, &req.blockData);
+        res_init(0x0C);
         res.RW_status[0] = 0;
         res.RW_status[1] = 0;
       }

--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -7,7 +7,7 @@
 #elif defined(ESP8266)
 #pragma message "当前的开发板是 ESP8266"
 #define SerialDevice Serial
-//#define PN532_SPI_SS D4
+#define PN532_SPI_SS D4
 #define LED_PIN D5
 
 #elif defined(ESP32)

--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -400,7 +400,7 @@ void nfc_felica_through() {
     case FelicaWriteWithoutEncryptData:
       {
         uint16_t serviceCodeList = req.serviceCodeList[1] << 8 | req.serviceCodeList[0];
-        uint16_t blockList = (uint16_t)(req.blockList_write[0][0] << 8 | req.blockList_write[0][1]);
+        uint16_t blockList = (uint16_t)(req.blockList[0][0] << 8 | req.blockList[0][1]);
         nfc.felica_WriteWithoutEncryption(1, &serviceCodeList, 1, &blockList, &req.blockData);
         res_init(0x0C);
         res.RW_status[0] = 0;

--- a/Arduino-Aime-Reader.ino
+++ b/Arduino-Aime-Reader.ino
@@ -95,8 +95,12 @@ void loop() {
     case CMD_CARD_HALT:
     case CMD_EXT_TO_NORMAL_MODE:
     case CMD_TO_UPDATER_MODE:
+      res_init();
+      break;
+
     case CMD_SEND_HEX_DATA:
       res_init();
+      res.status = STATUS_COMP_DUMMY_3RD;
       break;
 
     case STATUS_SUM_ERROR:


### PR DESCRIPTION
felica的读写在某些需要验证MAC_A的服务器上是很重要的操作。根据索尼官方的Felica-LiteS使用手册以及15396抓包数据，游戏只会向0x8080区块写入数值。0x8080为felica liteS的random challenge区块，验证MAC_A的流程即是先将16个随机字符写入8080区块，之后读取MAC_A区块即可。而MAC_A区块计算的值不仅是根据random challenge，还会将同一读取命令中前面读取的其他非MAC_A区块的数值也纳入计算中，又根据抓包数据以及实践分析，在发出读取命令时，必须在同一条命令中读取全部四个区块（即0x8082,0x8086,0x8090,0x8091)才能获取到服务器期望的正确MAC_A。关于使用PN532库读取felica四个区块会报错的问题，请见我提出的issus：https://github.com/Seeed-Studio/PN532/issues/147 以及 https://github.com/Seeed-Studio/PN532/issues/148
修改后的PN532库请见https://github.com/QHPaeek/PN532
经过测试，在需要MAC_A验证的服务器上可以正确刷入felica卡。

另外，经过对比15396抓包数据，发现：
15396的回复:
out:e0 30 00 05 61 2b 3a 31 30 30 30 30 30 30 30 30 43 39 34 34 43 30 30 30 43 39 34 36 39 30 30 30 43 39 34 36 39 30 30 30 43 39 34 36 39 30 30 45 39 be
in: e0 06 00 05 61 20 00 8c //CMD_SEND_HEX_DATA
arduino读卡器的回复:
out : e0 30 00 05 61 2b 3a 31 30 30 30 30 30 30 30 30 43 39 34 34 43 30 30 30 43 39 34 36 39 30 30 30 43 39 34 36 39 30 30 30 43 39 34 36 39 30 30 45 39 be
in : e0 06 00 05 61 00 00 6c //CMD_SEND_HEX_DATA
此错误似乎不影响读卡器的正常使用，但是会导致游戏反复向读卡器发送命令，可能会造成未知影响。修复后一切正常。