### PR TITLE
再次修复游戏尝试给读卡器刷固件，更加正确的felica读取函数

### DIFF
--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -359,7 +359,6 @@ void nfc_mifare_read() { // 认证成功后，读取 MIFARE 指定的 block
 // response也可以直接打包转发回游戏
 void nfc_felica_through() { // FeliCa 处理函数
   uint8_t response_length = 0;
-  req.encap_code &= 0x0F; //把0xA4处理为0x04（FELICA_CMD_REQUEST_RESPONSE）
   if (nfc.inDataExchange(&req.encap_len, req.encap_len, &res.encap_len, &response_length)) {
     res_init(response_length);
     //如果成功的话 res.encap_len == response_length

--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -360,7 +360,7 @@ void nfc_mifare_read() { // 认证成功后，读取 MIFARE 指定的 block
 void nfc_felica_through() { // FeliCa 处理函数
   uint8_t response_length = 0;
   req.encap_code &= 0x0F; //把0xA4处理为0x04（FELICA_CMD_REQUEST_RESPONSE）
-  if (nfc.inDataExchange(&req.encap_len, req.encap_len, &res.encap_len, response_length)) {
+  if (nfc.inDataExchange(&req.encap_len, req.encap_len, &res.encap_len, &response_length)) {
     res_init(response_length);
     //如果成功的话 res.encap_len == response_length
   } else {

--- a/Aime_Reader.h
+++ b/Aime_Reader.h
@@ -358,7 +358,7 @@ void nfc_mifare_read() { // 认证成功后，读取 MIFARE 指定的 block
 // 游戏发送的0x71命令后面的包实际上是完整的与Felica卡片直接通信的包，可以转发进PN532库直接用
 // response也可以直接打包转发回游戏
 void nfc_felica_through() { // FeliCa 处理函数
-  uint8_t response_length = 0;
+  uint8_t response_length = 0xFF;
   if (nfc.inDataExchange(&req.encap_len, req.encap_len, &res.encap_len, &response_length)) {
     res_init(response_length);
     //如果成功的话 res.encap_len == response_length

--- a/Arduino-Aime-Reader.ino
+++ b/Arduino-Aime-Reader.ino
@@ -103,15 +103,18 @@ void loop() {
     case CMD_CARD_SELECT:
     case CMD_CARD_HALT:
     case CMD_EXT_TO_NORMAL_MODE:
-    case CMD_TO_UPDATER_MODE: // 作用未知，根据串口数据猜测
       res_init();
+    case CMD_FIRMWARE_UPDATE:
+      res_init();
+      res.status = STATUS_FIRM_UPDATE_SUCCESS;
+      //当读卡器发送的FW版本与amdaemon要求的版本不一致时，
+      //游戏会发送0x60使读卡器进入update模式，再通过0x64再次更新，
+      //此时需要回复0x08方可再次跳过更新
       break;
-
     case CMD_SEND_HEX_DATA: // 非 TN32MSEC003S 时，可能会触发固件更新逻辑
       res_init();
       res.status = STATUS_COMP_DUMMY_3RD;
-      // 回复 STATUS_COMP_DUMMY_3RD 可以跳过更新
-      // 如果因 fw、hw 变动导致触发更新，该回复会导致更新失败，amdaemon 崩溃
+      // 读卡器HW版本是837-15286时应该回复0x10, 837-15396回复0x20
       break;
 
     case STATUS_SUM_ERROR: // 读取数据校验失败时的回复，未确认效果

--- a/Arduino-Aime-Reader.ino
+++ b/Arduino-Aime-Reader.ino
@@ -103,7 +103,9 @@ void loop() {
     case CMD_CARD_SELECT:
     case CMD_CARD_HALT:
     case CMD_EXT_TO_NORMAL_MODE:
+    case CMD_TO_UPDATER_MODE:
       res_init();
+      break;
     case CMD_FIRMWARE_UPDATE:
       res_init();
       res.status = STATUS_FIRM_UPDATE_SUCCESS;


### PR DESCRIPTION
同步我自己的部分逆向结果

当读卡器发送的FW版本与amdaemon要求的版本不一致时，游戏会发送0x60使读卡器进入update模式，再通过0x64再次更新，此时需要回复0x08方可再次跳过更新。并且0x64需要跳过packet_read()函数内的checksum检查，因为checksum在长达300个字节的包的包尾。
0x61命令的response取决于读卡器HW版本，837-15286为0x10，15396为0x20

以及 Felica的包实际上是可以不处理，直接转发给pn532的